### PR TITLE
Implement parser for type arguments on structs and oneofs

### DIFF
--- a/compiler/src/ast.ts
+++ b/compiler/src/ast.ts
@@ -51,7 +51,7 @@ export interface Field<T> {
 
 interface Genericizable {
   // Should probably be augmented to be resolvable.
-  typeArgs: string[];
+  typeParams: string[];
 }
 
 export interface StructType<T> extends Genericizable {

--- a/compiler/src/ast.ts
+++ b/compiler/src/ast.ts
@@ -49,12 +49,17 @@ export interface Field<T> {
   baseType: T;
 }
 
-export interface StructType<T> {
+interface Genericizable {
+  // Should probably be augmented to be resolvable.
+  typeArgs: string[];
+}
+
+export interface StructType<T> extends Genericizable {
   type: "struct";
   fields: Array<Field<T>>;
 }
 
-export interface OneOfType<T> {
+export interface OneOfType<T> extends Genericizable {
   type: "oneof";
   fields: Array<Field<T>>;
 }

--- a/compiler/src/ast.ts
+++ b/compiler/src/ast.ts
@@ -92,7 +92,15 @@ export interface Import {
   path: string;
 }
 
-export type VarRHS<T> =
+export type PrimitiveType =
+  | IntegerType
+  | DoubleType
+  | BooleanType
+  | StringType
+  | NullType;
+
+export type Value<T> =
+  | PrimitiveType
   | Channel<T>
   | RPC<T>
   | StructType<T>
@@ -103,7 +111,7 @@ export type VarRHS<T> =
 export interface VariableDeclaration<T> {
   statementType: "declaration";
   name: string;
-  value: VarRHS<T>;
+  value: Value<T>;
 }
 
 export type Statement<T> = VariableDeclaration<T>;

--- a/compiler/src/generators/typescript-shared/genNodeDecls.ts
+++ b/compiler/src/generators/typescript-shared/genNodeDecls.ts
@@ -1,7 +1,7 @@
 import {
   VariableDeclaration,
   Representable,
-  VarRHS,
+  Value,
   Primitive,
 } from "../../ast";
 
@@ -23,7 +23,7 @@ const generateNodeDeclaration = (
 export type ${name} = ExtractNodeType<typeof ${name}__node>;`;
 };
 
-const genTypeForRhs = (rhs: VarRHS<Representable>): string => {
+const genTypeForRhs = (rhs: Value<Representable>): string => {
   switch (rhs.type) {
     case "channel": {
       const incoming = genTypeForRepresentable(rhs.incoming.baseType);

--- a/compiler/src/gst.ts
+++ b/compiler/src/gst.ts
@@ -1,0 +1,4 @@
+import { Value } from "./ast";
+
+export type SymbolKey = string;
+export type GlobalSymbolTable = { [key: string]: Value<SymbolKey> };

--- a/compiler/src/lexer.ts
+++ b/compiler/src/lexer.ts
@@ -12,12 +12,13 @@ import {
   Parser,
   apFirst,
   many,
-  fail,
   many1,
   sat,
   either,
   eof,
 } from "parser-ts/lib/Parser";
+
+import { anyOf } from "./util";
 
 function isNonNewline(char: string): boolean {
   return char !== "\n";
@@ -180,10 +181,6 @@ export type Token =
   | OpenBracketToken
   | CloseBracketToken
   | NameToken;
-
-const anyOf = <S, T>(parsers: Array<Parser<S, T>>) => {
-  return parsers.reduceRight((acc, cur) => either(cur, () => acc), fail());
-};
 
 export const lexer: Parser<string, Token[]> = map(
   // jank way of removing null tokens, which as of yet were unallowed

--- a/compiler/src/resolve.ts
+++ b/compiler/src/resolve.ts
@@ -302,13 +302,14 @@ function resolveDecl(
       ),
     };
   } else {
-    const { type, fields } = decl.value;
+    const { type, fields, typeArgs } = decl.value;
     newVal = {
       type,
       fields: fields.map(({ name, baseType }) => ({
         name,
         baseType: qResolveRev(baseType),
       })),
+      typeArgs,
     };
   }
 

--- a/compiler/src/resolve.ts
+++ b/compiler/src/resolve.ts
@@ -4,7 +4,7 @@ import {
   Reference,
   Primitive,
   VariableDeclaration,
-  VarRHS,
+  Value,
 } from "./ast";
 import path from "path";
 
@@ -238,7 +238,7 @@ function resolveDecl(
       currentNamespace
     );
 
-  let newVal: VarRHS<Representable>;
+  let newVal: Value<Representable>;
   if (decl.value.type === "channel") {
     const { type, name, incoming, outgoing } = decl.value;
     newVal = {
@@ -301,7 +301,7 @@ function resolveDecl(
         resolveDecl(ref, context, nextReffedVars, prevReffedFiles, load, name)
       ),
     };
-  } else {
+  } else if (decl.value.type === "oneof" || decl.value.type === "struct") {
     const { type, fields, typeParams } = decl.value;
     newVal = {
       type,
@@ -311,6 +311,9 @@ function resolveDecl(
       })),
       typeParams,
     };
+  } else {
+    // Otherwise it's a primitive!
+    newVal = decl.value;
   }
 
   return {

--- a/compiler/src/resolve.ts
+++ b/compiler/src/resolve.ts
@@ -302,14 +302,14 @@ function resolveDecl(
       ),
     };
   } else {
-    const { type, fields, typeArgs } = decl.value;
+    const { type, fields, typeParams } = decl.value;
     newVal = {
       type,
       fields: fields.map(({ name, baseType }) => ({
         name,
         baseType: qResolveRev(baseType),
       })),
-      typeArgs,
+      typeParams,
     };
   }
 

--- a/compiler/src/resolve.ts
+++ b/compiler/src/resolve.ts
@@ -7,6 +7,7 @@ import {
   Value,
 } from "./ast";
 import path from "path";
+import { loadButteryFile } from "./pipeline";
 
 const validMapKey = (key: Primitive) =>
   [
@@ -15,8 +16,6 @@ const validMapKey = (key: Primitive) =>
     Primitive.integer,
     Primitive.string,
   ].includes(key);
-
-type LoadFn = (file: string) => ButteryFile<Reference>;
 
 const getRepresentableFromVar = (
   resolvedDecl: VariableDeclaration<Representable>
@@ -41,7 +40,6 @@ function maybeGetBuiltin(
   context: ButteryFile<Reference>,
   prevReffedVars: string[],
   prevReffedFiles: string[],
-  load: LoadFn,
   namespaceContext?: string
 ): Representable | undefined {
   // ew on this cast. I need to rethink enums here.
@@ -66,7 +64,7 @@ function maybeGetBuiltin(
         context,
         prevReffedVars,
         prevReffedFiles,
-        load,
+
         namespaceContext
       ),
     };
@@ -89,7 +87,7 @@ function maybeGetBuiltin(
         context,
         prevReffedVars,
         prevReffedFiles,
-        load,
+
         namespaceContext
       ),
     };
@@ -106,7 +104,7 @@ function maybeGetBuiltin(
         context,
         prevReffedVars,
         prevReffedFiles,
-        load,
+
         namespaceContext
       ),
     };
@@ -118,7 +116,6 @@ function resolveRef(
   context: ButteryFile<Reference>,
   prevReffedVars: string[],
   prevReffedFiles: string[],
-  load: LoadFn,
   namespaceContext?: string
 ): Representable {
   const { ref, namespace } = refObject;
@@ -129,7 +126,7 @@ function resolveRef(
     context,
     prevReffedVars,
     prevReffedFiles,
-    load,
+
     namespaceContext
   );
 
@@ -153,7 +150,7 @@ function resolveRef(
         if (prevReffedFiles.includes(loadPath)) {
           throw new Error(`Circular reference in files detected: ${loadPath}`);
         }
-        const tmp = load(loadPath).variables.find(
+        const tmp = loadButteryFile(loadPath).variables.find(
           (decl) => decl.name === importName
         );
         if (!tmp) {
@@ -205,7 +202,7 @@ function resolveRef(
       context,
       prevReffedVars,
       prevReffedFiles,
-      load,
+
       namespaceContext
     )
   );
@@ -216,7 +213,6 @@ function resolveDecl(
   context: ButteryFile<Reference>,
   prevReffedVars: string[],
   prevReffedFiles: string[],
-  load: LoadFn,
   currentNamespace?: string // What namespace are we currently in?
 ): VariableDeclaration<Representable> {
   const scopedName = currentNamespace
@@ -234,7 +230,7 @@ function resolveDecl(
       context,
       nextReffedVars,
       prevReffedFiles,
-      load,
+
       currentNamespace
     );
 
@@ -277,20 +273,15 @@ function resolveDecl(
     if (prevReffedFiles.includes(loadPath)) {
       throw new Error(`Circular reference in files detected: ${loadPath}`);
     }
-    const file = load(loadPath);
+    const file = loadButteryFile(loadPath);
     const reffedVar = file.variables.find((v) => v.name === ref);
 
     if (!reffedVar) {
       throw new Error(`File ${loadPath} does not define ${ref}`);
     }
 
-    newVal = resolveDecl(
-      reffedVar,
-      file,
-      [],
-      prevReffedFiles.concat(file.path),
-      load
-    ).value;
+    newVal = resolveDecl(reffedVar, file, [], prevReffedFiles.concat(file.path))
+      .value;
   } else if (decl.value.type === "service") {
     const { type, name, variables } = decl.value;
 
@@ -298,7 +289,7 @@ function resolveDecl(
       type,
       name,
       variables: variables.map((ref: VariableDeclaration<Reference>) =>
-        resolveDecl(ref, context, nextReffedVars, prevReffedFiles, load, name)
+        resolveDecl(ref, context, nextReffedVars, prevReffedFiles, name)
       ),
     };
   } else if (decl.value.type === "oneof" || decl.value.type === "struct") {
@@ -330,7 +321,7 @@ export function resolve(
   // circ reference betw. files solved in load()
   // so now we just have to solve it here.
   const newVars = refFile.variables.map((variable) =>
-    resolveDecl(variable, refFile, [], [refFile.path], load)
+    resolveDecl(variable, refFile, [], [refFile.path])
   );
 
   return {

--- a/compiler/src/tests/parser.spec.ts
+++ b/compiler/src/tests/parser.spec.ts
@@ -187,7 +187,7 @@ describe("Parsing", function () {
               baseType: { ref: "Dog", typeArgs: [] },
             },
           ],
-          typeArgs: [],
+          typeParams: [],
         },
       };
       chai.assert.deepEqual(ref, targetRef);
@@ -208,7 +208,7 @@ describe("Parsing", function () {
         name: "Hello",
         value: {
           type: "struct",
-          typeArgs: [],
+          typeParams: [],
           fields: [
             {
               baseType: {
@@ -271,7 +271,7 @@ describe("Parsing", function () {
         name: "Hello",
         value: {
           type: "oneof",
-          typeArgs: [],
+          typeParams: [],
           fields: [
             {
               name: "fat",
@@ -572,7 +572,7 @@ service BloopService:
             name: "WhoBloopedRequest",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 {
                   name: "bloop",
@@ -595,7 +595,7 @@ service BloopService:
             name: "WhoBloopedResponse",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 {
                   name: "scoop",

--- a/compiler/src/tests/parser.spec.ts
+++ b/compiler/src/tests/parser.spec.ts
@@ -255,6 +255,42 @@ describe("Parsing", function () {
       };
       chai.assert.deepEqual(ref, targetRef);
     });
+
+    it("should correctly parse a proto a generic declaration", function () {
+      const input = `struct Hello<TypeOne, TypeTwo>:
+  foo: TypeOne
+  bar: TypeTwo`;
+
+      const parsed = parseStruct(input);
+      // parsing succeeds!
+      assert(isRight(parsed));
+      const ref = parsed.right.value;
+      const targetRef: VariableDeclaration<Reference> = {
+        statementType: "declaration",
+        name: "Hello",
+        value: {
+          type: "struct",
+          typeParams: ["TypeOne", "TypeTwo"],
+          fields: [
+            {
+              baseType: {
+                ref: "TypeOne",
+                typeArgs: [],
+              },
+              name: "foo",
+            },
+            {
+              baseType: {
+                ref: "TypeTwo",
+                typeArgs: [],
+              },
+              name: "bar",
+            },
+          ],
+        },
+      };
+      chai.assert.deepEqual(ref, targetRef);
+    });
   });
 
   describe("OneOfDecl", function () {

--- a/compiler/src/tests/parser.spec.ts
+++ b/compiler/src/tests/parser.spec.ts
@@ -488,7 +488,17 @@ describe("Parsing", function () {
       };
       chai.assert.deepEqual(ref, targetRef);
     });
+    it("should fail to parse a service with type parameters", function () {
+      const input = `service HiService<Foo>:
+  rpc Hello:
+    request: List<Map<string, Dog>>
+    response: bool`;
+
+      // Frankly this shouldn't throw, but fail to parse, but whatever rn.
+      assert.throws(() => parseService(input));
+    });
   });
+
   describe("Import", function () {
     const parseImport = buildTestParser(importParser);
 

--- a/compiler/src/tests/parser.spec.ts
+++ b/compiler/src/tests/parser.spec.ts
@@ -150,7 +150,7 @@ describe("Parsing", function () {
       const ref = parsed.right.value;
       const targetRef: Field<Reference> = {
         name: "myFieldName",
-        
+
         baseType: {
           ref: "number",
           typeArgs: [],
@@ -178,15 +178,16 @@ describe("Parsing", function () {
           fields: [
             {
               name: "fat",
-              
+
               baseType: { ref: "Dog", typeArgs: [] },
             },
             {
               name: "cat",
-              
+
               baseType: { ref: "Dog", typeArgs: [] },
             },
           ],
+          typeArgs: [],
         },
       };
       chai.assert.deepEqual(ref, targetRef);
@@ -207,6 +208,7 @@ describe("Parsing", function () {
         name: "Hello",
         value: {
           type: "struct",
+          typeArgs: [],
           fields: [
             {
               baseType: {
@@ -228,7 +230,6 @@ describe("Parsing", function () {
                 ],
               },
               name: "fatDogs",
-              
             },
             {
               baseType: {
@@ -236,7 +237,6 @@ describe("Parsing", function () {
                 typeArgs: [],
               },
               name: "catTracksSeen",
-              
             },
             {
               baseType: {
@@ -249,7 +249,6 @@ describe("Parsing", function () {
                 ],
               },
               name: "peopleWhoLetTheDogsOut",
-              
             },
           ],
         },
@@ -272,15 +271,16 @@ describe("Parsing", function () {
         name: "Hello",
         value: {
           type: "oneof",
+          typeArgs: [],
           fields: [
             {
               name: "fat",
-              
+
               baseType: { ref: "Dog", typeArgs: [] },
             },
             {
               name: "cat",
-              
+
               baseType: { ref: "Dog", typeArgs: [] },
             },
           ],
@@ -327,7 +327,6 @@ describe("Parsing", function () {
               ],
             },
             name: "request",
-            
           },
           response: {
             baseType: {
@@ -335,7 +334,6 @@ describe("Parsing", function () {
               typeArgs: [],
             },
             name: "response",
-            
           },
         },
       };
@@ -380,7 +378,6 @@ describe("Parsing", function () {
               ],
             },
             name: "incoming",
-            
           },
           outgoing: {
             baseType: {
@@ -388,7 +385,6 @@ describe("Parsing", function () {
               typeArgs: [],
             },
             name: "outgoing",
-            
           },
         },
       };
@@ -441,7 +437,6 @@ describe("Parsing", function () {
                     ],
                   },
                   name: "request",
-                  
                 },
                 response: {
                   baseType: {
@@ -449,7 +444,6 @@ describe("Parsing", function () {
                     typeArgs: [],
                   },
                   name: "response",
-                  
                 },
               },
             },
@@ -578,15 +572,16 @@ service BloopService:
             name: "WhoBloopedRequest",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 {
                   name: "bloop",
-                  
+
                   baseType: { ref: "Bloop", typeArgs: [] },
                 },
                 {
                   name: "includeExtras",
-                  
+
                   baseType: {
                     ref: "Optional",
                     typeArgs: [{ ref: "boolean", typeArgs: [] }],
@@ -600,15 +595,16 @@ service BloopService:
             name: "WhoBloopedResponse",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 {
                   name: "scoop",
-                  
+
                   baseType: { ref: "Scoop", typeArgs: [] },
                 },
                 {
                   name: "bloopers",
-                  
+
                   baseType: {
                     ref: "List",
                     typeArgs: [{ ref: "Bloopers", typeArgs: [] }],
@@ -632,12 +628,12 @@ service BloopService:
                     name: "WhoBlooped",
                     request: {
                       name: "request",
-                      
+
                       baseType: { ref: "WhoBloopedRequest", typeArgs: [] },
                     },
                     response: {
                       name: "response",
-                      
+
                       baseType: { ref: "WhoBloopedResponse", typeArgs: [] },
                     },
                   },

--- a/compiler/src/tests/resolve.spec.ts
+++ b/compiler/src/tests/resolve.spec.ts
@@ -13,7 +13,7 @@ describe("Resolving", function () {
             name: "Person",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 { name: "name", baseType: { type: "string" } },
                 {
@@ -28,13 +28,13 @@ describe("Resolving", function () {
             name: "Message",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 {
                   name: "author",
                   baseType: {
                     type: "struct",
-                    typeArgs: [],
+                    typeParams: [],
                     fields: [
                       {
                         name: "name",
@@ -62,7 +62,7 @@ describe("Resolving", function () {
                     key: "string",
                     value: {
                       type: "struct",
-                      typeArgs: [],
+                      typeParams: [],
                       fields: [
                         {
                           name: "name",
@@ -98,7 +98,7 @@ describe("Resolving", function () {
                         type: "list",
                         value: {
                           type: "struct",
-                          typeArgs: [],
+                          typeParams: [],
                           fields: [
                             {
                               name: "name",
@@ -116,7 +116,7 @@ describe("Resolving", function () {
                       name: "response",
                       baseType: {
                         type: "struct",
-                        typeArgs: [],
+                        typeParams: [],
                         fields: [
                           {
                             name: "name",
@@ -141,13 +141,13 @@ describe("Resolving", function () {
                       name: "incoming",
                       baseType: {
                         type: "struct",
-                        typeArgs: [],
+                        typeParams: [],
                         fields: [
                           {
                             name: "author",
                             baseType: {
                               type: "struct",
-                              typeArgs: [],
+                              typeParams: [],
                               fields: [
                                 {
                                   name: "name",
@@ -175,7 +175,7 @@ describe("Resolving", function () {
                               key: "string",
                               value: {
                                 type: "struct",
-                                typeArgs: [],
+                                typeParams: [],
                                 fields: [
                                   {
                                     name: "name",
@@ -196,13 +196,13 @@ describe("Resolving", function () {
                       name: "outgoing",
                       baseType: {
                         type: "struct",
-                        typeArgs: [],
+                        typeParams: [],
                         fields: [
                           {
                             name: "author",
                             baseType: {
                               type: "struct",
-                              typeArgs: [],
+                              typeParams: [],
                               fields: [
                                 {
                                   name: "name",
@@ -230,7 +230,7 @@ describe("Resolving", function () {
                               key: "string",
                               value: {
                                 type: "struct",
-                                typeArgs: [],
+                                typeParams: [],
                                 fields: [
                                   {
                                     name: "name",
@@ -269,7 +269,7 @@ describe("Resolving", function () {
             name: "Person",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 { name: "name", baseType: { type: "string" } },
                 {
@@ -284,7 +284,7 @@ describe("Resolving", function () {
             name: "Slot",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 {
                   name: "people",
@@ -292,7 +292,7 @@ describe("Resolving", function () {
                     type: "list",
                     value: {
                       type: "struct",
-                      typeArgs: [],
+                      typeParams: [],
                       fields: [
                         {
                           name: "name",
@@ -322,7 +322,7 @@ describe("Resolving", function () {
             name: "AddToPartyResponse",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 {
                   name: "success",
@@ -334,7 +334,7 @@ describe("Resolving", function () {
                     type: "optional",
                     value: {
                       type: "struct",
-                      typeArgs: [],
+                      typeParams: [],
                       fields: [
                         {
                           name: "people",
@@ -342,7 +342,7 @@ describe("Resolving", function () {
                             type: "list",
                             value: {
                               type: "struct",
-                              typeArgs: [],
+                              typeParams: [],
                               fields: [
                                 {
                                   name: "name",
@@ -379,7 +379,7 @@ describe("Resolving", function () {
             name: "ChatMessage",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 {
                   name: "time",
@@ -397,7 +397,7 @@ describe("Resolving", function () {
             name: "ChatUpdate",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 {
                   name: "time",
@@ -411,7 +411,7 @@ describe("Resolving", function () {
                   name: "author",
                   baseType: {
                     type: "struct",
-                    typeArgs: [],
+                    typeParams: [],
                     fields: [
                       {
                         name: "name",
@@ -444,7 +444,7 @@ describe("Resolving", function () {
                       name: "request",
                       baseType: {
                         type: "struct",
-                        typeArgs: [],
+                        typeParams: [],
                         fields: [
                           {
                             name: "name",
@@ -464,7 +464,7 @@ describe("Resolving", function () {
                       name: "response",
                       baseType: {
                         type: "struct",
-                        typeArgs: [],
+                        typeParams: [],
                         fields: [
                           {
                             name: "success",
@@ -476,7 +476,7 @@ describe("Resolving", function () {
                               type: "optional",
                               value: {
                                 type: "struct",
-                                typeArgs: [],
+                                typeParams: [],
                                 fields: [
                                   {
                                     name: "people",
@@ -484,7 +484,7 @@ describe("Resolving", function () {
                                       type: "list",
                                       value: {
                                         type: "struct",
-                                        typeArgs: [],
+                                        typeParams: [],
                                         fields: [
                                           {
                                             name: "name",
@@ -528,7 +528,7 @@ describe("Resolving", function () {
                       name: "incoming",
                       baseType: {
                         type: "struct",
-                        typeArgs: [],
+                        typeParams: [],
                         fields: [
                           {
                             name: "time",
@@ -545,7 +545,7 @@ describe("Resolving", function () {
                       name: "outgoing",
                       baseType: {
                         type: "struct",
-                        typeArgs: [],
+                        typeParams: [],
                         fields: [
                           {
                             name: "time",
@@ -559,7 +559,7 @@ describe("Resolving", function () {
                             name: "author",
                             baseType: {
                               type: "struct",
-                              typeArgs: [],
+                              typeParams: [],
                               fields: [
                                 {
                                   name: "name",
@@ -613,7 +613,7 @@ describe("Resolving", function () {
                   name: "Meal",
                   value: {
                     type: "struct",
-                    typeArgs: [],
+                    typeParams: [],
                     fields: [
                       {
                         name: "id",
@@ -635,7 +635,7 @@ describe("Resolving", function () {
                   name: "Restaurant",
                   value: {
                     type: "struct",
-                    typeArgs: [],
+                    typeParams: [],
                     fields: [
                       {
                         name: "id",
@@ -655,7 +655,7 @@ describe("Resolving", function () {
                           type: "list",
                           value: {
                             type: "struct",
-                            typeArgs: [],
+                            typeParams: [],
                             fields: [
                               {
                                 name: "id",
@@ -692,7 +692,7 @@ describe("Resolving", function () {
                         type: "list",
                         value: {
                           type: "struct",
-                          typeArgs: [],
+                          typeParams: [],
                           fields: [
                             {
                               name: "id",
@@ -712,7 +712,7 @@ describe("Resolving", function () {
                                 type: "list",
                                 value: {
                                   type: "struct",
-                                  typeArgs: [],
+                                  typeParams: [],
                                   fields: [
                                     {
                                       name: "id",
@@ -744,7 +744,7 @@ describe("Resolving", function () {
             name: "User",
             value: {
               type: "struct",
-              typeArgs: [],
+              typeParams: [],
               fields: [
                 {
                   name: "id",
@@ -773,7 +773,7 @@ describe("Resolving", function () {
                   name: "Order",
                   value: {
                     type: "struct",
-                    typeArgs: [],
+                    typeParams: [],
                     fields: [
                       {
                         name: "restaurantId",
@@ -800,7 +800,7 @@ describe("Resolving", function () {
                       name: "request",
                       baseType: {
                         type: "struct",
-                        typeArgs: [],
+                        typeParams: [],
                         fields: [
                           {
                             name: "restaurantId",
@@ -839,7 +839,7 @@ describe("Resolving", function () {
                         type: "list",
                         value: {
                           type: "struct",
-                          typeArgs: [],
+                          typeParams: [],
                           fields: [
                             {
                               name: "id",

--- a/compiler/src/tests/resolve.spec.ts
+++ b/compiler/src/tests/resolve.spec.ts
@@ -13,6 +13,7 @@ describe("Resolving", function () {
             name: "Person",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 { name: "name", baseType: { type: "string" } },
                 {
@@ -27,11 +28,13 @@ describe("Resolving", function () {
             name: "Message",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 {
                   name: "author",
                   baseType: {
                     type: "struct",
+                    typeArgs: [],
                     fields: [
                       {
                         name: "name",
@@ -59,6 +62,7 @@ describe("Resolving", function () {
                     key: "string",
                     value: {
                       type: "struct",
+                      typeArgs: [],
                       fields: [
                         {
                           name: "name",
@@ -94,6 +98,7 @@ describe("Resolving", function () {
                         type: "list",
                         value: {
                           type: "struct",
+                          typeArgs: [],
                           fields: [
                             {
                               name: "name",
@@ -111,6 +116,7 @@ describe("Resolving", function () {
                       name: "response",
                       baseType: {
                         type: "struct",
+                        typeArgs: [],
                         fields: [
                           {
                             name: "name",
@@ -135,11 +141,13 @@ describe("Resolving", function () {
                       name: "incoming",
                       baseType: {
                         type: "struct",
+                        typeArgs: [],
                         fields: [
                           {
                             name: "author",
                             baseType: {
                               type: "struct",
+                              typeArgs: [],
                               fields: [
                                 {
                                   name: "name",
@@ -167,6 +175,7 @@ describe("Resolving", function () {
                               key: "string",
                               value: {
                                 type: "struct",
+                                typeArgs: [],
                                 fields: [
                                   {
                                     name: "name",
@@ -187,11 +196,13 @@ describe("Resolving", function () {
                       name: "outgoing",
                       baseType: {
                         type: "struct",
+                        typeArgs: [],
                         fields: [
                           {
                             name: "author",
                             baseType: {
                               type: "struct",
+                              typeArgs: [],
                               fields: [
                                 {
                                   name: "name",
@@ -219,6 +230,7 @@ describe("Resolving", function () {
                               key: "string",
                               value: {
                                 type: "struct",
+                                typeArgs: [],
                                 fields: [
                                   {
                                     name: "name",
@@ -257,6 +269,7 @@ describe("Resolving", function () {
             name: "Person",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 { name: "name", baseType: { type: "string" } },
                 {
@@ -271,6 +284,7 @@ describe("Resolving", function () {
             name: "Slot",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 {
                   name: "people",
@@ -278,6 +292,7 @@ describe("Resolving", function () {
                     type: "list",
                     value: {
                       type: "struct",
+                      typeArgs: [],
                       fields: [
                         {
                           name: "name",
@@ -307,6 +322,7 @@ describe("Resolving", function () {
             name: "AddToPartyResponse",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 {
                   name: "success",
@@ -318,6 +334,7 @@ describe("Resolving", function () {
                     type: "optional",
                     value: {
                       type: "struct",
+                      typeArgs: [],
                       fields: [
                         {
                           name: "people",
@@ -325,6 +342,7 @@ describe("Resolving", function () {
                             type: "list",
                             value: {
                               type: "struct",
+                              typeArgs: [],
                               fields: [
                                 {
                                   name: "name",
@@ -361,6 +379,7 @@ describe("Resolving", function () {
             name: "ChatMessage",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 {
                   name: "time",
@@ -378,6 +397,7 @@ describe("Resolving", function () {
             name: "ChatUpdate",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 {
                   name: "time",
@@ -391,6 +411,7 @@ describe("Resolving", function () {
                   name: "author",
                   baseType: {
                     type: "struct",
+                    typeArgs: [],
                     fields: [
                       {
                         name: "name",
@@ -423,6 +444,7 @@ describe("Resolving", function () {
                       name: "request",
                       baseType: {
                         type: "struct",
+                        typeArgs: [],
                         fields: [
                           {
                             name: "name",
@@ -442,6 +464,7 @@ describe("Resolving", function () {
                       name: "response",
                       baseType: {
                         type: "struct",
+                        typeArgs: [],
                         fields: [
                           {
                             name: "success",
@@ -453,6 +476,7 @@ describe("Resolving", function () {
                               type: "optional",
                               value: {
                                 type: "struct",
+                                typeArgs: [],
                                 fields: [
                                   {
                                     name: "people",
@@ -460,6 +484,7 @@ describe("Resolving", function () {
                                       type: "list",
                                       value: {
                                         type: "struct",
+                                        typeArgs: [],
                                         fields: [
                                           {
                                             name: "name",
@@ -503,6 +528,7 @@ describe("Resolving", function () {
                       name: "incoming",
                       baseType: {
                         type: "struct",
+                        typeArgs: [],
                         fields: [
                           {
                             name: "time",
@@ -519,6 +545,7 @@ describe("Resolving", function () {
                       name: "outgoing",
                       baseType: {
                         type: "struct",
+                        typeArgs: [],
                         fields: [
                           {
                             name: "time",
@@ -532,6 +559,7 @@ describe("Resolving", function () {
                             name: "author",
                             baseType: {
                               type: "struct",
+                              typeArgs: [],
                               fields: [
                                 {
                                   name: "name",
@@ -585,6 +613,7 @@ describe("Resolving", function () {
                   name: "Meal",
                   value: {
                     type: "struct",
+                    typeArgs: [],
                     fields: [
                       {
                         name: "id",
@@ -606,6 +635,7 @@ describe("Resolving", function () {
                   name: "Restaurant",
                   value: {
                     type: "struct",
+                    typeArgs: [],
                     fields: [
                       {
                         name: "id",
@@ -625,6 +655,7 @@ describe("Resolving", function () {
                           type: "list",
                           value: {
                             type: "struct",
+                            typeArgs: [],
                             fields: [
                               {
                                 name: "id",
@@ -661,6 +692,7 @@ describe("Resolving", function () {
                         type: "list",
                         value: {
                           type: "struct",
+                          typeArgs: [],
                           fields: [
                             {
                               name: "id",
@@ -680,6 +712,7 @@ describe("Resolving", function () {
                                 type: "list",
                                 value: {
                                   type: "struct",
+                                  typeArgs: [],
                                   fields: [
                                     {
                                       name: "id",
@@ -711,6 +744,7 @@ describe("Resolving", function () {
             name: "User",
             value: {
               type: "struct",
+              typeArgs: [],
               fields: [
                 {
                   name: "id",
@@ -739,6 +773,7 @@ describe("Resolving", function () {
                   name: "Order",
                   value: {
                     type: "struct",
+                    typeArgs: [],
                     fields: [
                       {
                         name: "restaurantId",
@@ -765,6 +800,7 @@ describe("Resolving", function () {
                       name: "request",
                       baseType: {
                         type: "struct",
+                        typeArgs: [],
                         fields: [
                           {
                             name: "restaurantId",
@@ -803,6 +839,7 @@ describe("Resolving", function () {
                         type: "list",
                         value: {
                           type: "struct",
+                          typeArgs: [],
                           fields: [
                             {
                               name: "id",

--- a/compiler/src/util.ts
+++ b/compiler/src/util.ts
@@ -1,0 +1,5 @@
+import { either, fail, Parser } from "parser-ts/lib/Parser";
+
+export const anyOf = <S, T>(parsers: Array<Parser<S, T>>) => {
+  return parsers.reduceRight((acc, cur) => either(cur, () => acc), fail());
+};


### PR DESCRIPTION
Right now the type arguments are ignored. For next release, we're gonna have to change that. Also a few more other things speculatively done but I frankly can't deal with this branch containing so much